### PR TITLE
Cancel on disconnect 

### DIFF
--- a/server/tests/e2e.rs
+++ b/server/tests/e2e.rs
@@ -69,6 +69,8 @@ async fn test_make_preimages_success() {
     let client = reqwest::Client::new();
     let builder = client.post("http://localhost:10080/derivation");
     let preimage_bytes = builder.json(&request).send().await.unwrap();
+    assert_eq!(preimage_bytes.status(), 200);
+
     let preimage_bytes = preimage_bytes.bytes().await.unwrap();
     let rollup_config = l2_client.rollup_config().await.unwrap();
 
@@ -86,7 +88,10 @@ async fn test_make_preimages_success() {
     let result = derivation.verify(chain_id, &rollup_config, oracle);
     match result {
         Ok(h) => tracing::info!("Derivation verified successfully {:? }", h),
-        Err(e) => tracing::error!("Derivation verification failed: {:?}", e),
+        Err(e) => {
+            tracing::error!("Derivation verification failed: {:?}", e);
+            panic!("Derivation verification failed");
+        },
     }
 }
 

--- a/server/tests/e2e.rs
+++ b/server/tests/e2e.rs
@@ -91,7 +91,7 @@ async fn test_make_preimages_success() {
         Err(e) => {
             tracing::error!("Derivation verification failed: {:?}", e);
             panic!("Derivation verification failed");
-        },
+        }
     }
 }
 


### PR DESCRIPTION
server-task and client_task are running behind the scenes even if the client disconnects because of tokio spawn. 
Stop spawning and use request task to terminate when the client disconnects.