### PR TITLE
Wait for LightClientFinalityUpdate exceeding LightClientUpdate

### DIFF
--- a/server/src/client/period.rs
+++ b/server/src/client/period.rs
@@ -40,7 +40,8 @@ pub const fn compute_period_from_slot(slot: u64) -> u64 {
 }
 
 /// Computes the slot from a timestamp and genesis time.
-/// Returns None if the timestamp is before genesis or not aligned to slot boundaries.
+/// Returns None if the timestamp is before genesis.
+/// Non-aligned timestamps are accepted and rounded down to the nearest slot.
 pub fn compute_slot_at_timestamp(timestamp: u64, genesis_time: u64) -> Option<u64> {
     if timestamp < genesis_time {
         return None;

--- a/server/src/collector.rs
+++ b/server/src/collector.rs
@@ -1380,7 +1380,8 @@ mod tests {
         // First call: only 20/32 participants (62.5% < 66.67%) -> insufficient
         // Second call: 32/32 participants (100%) -> sufficient
         let l1_head = B256::repeat_byte(0x11);
-        let full_participation = "0x".to_string() + &"ff".repeat(4); // 32 bits set
+        // 32 bits set
+        let full_participation = "0x".to_string() + &"ff".repeat(4);
         // 20 bits set: 0xfffff (20 bits) = 5 bytes of ff would be 40 bits, we need 20 bits
         // 20 bits = 0x000fffff -> but we need hex for Bitvector<32>
         // Actually for minimal feature (32 bits = 4 bytes):

--- a/server/src/collector.rs
+++ b/server/src/collector.rs
@@ -315,8 +315,6 @@ where
     /// 3. Collects the results asynchronously, returning an error if any task fails.
     /// 4. Once all tasks are complete, invokes the `commit_batch` method to commit the collected
     ///    results.
-    ///
-    /// ```
     async fn parallel_collect(
         &self,
         l1_head_hash: B256,

--- a/server/src/data/file_preimage_repository.rs
+++ b/server/src/data/file_preimage_repository.rs
@@ -255,7 +255,7 @@ mod tests {
         let got2 = repo.get(&m2).await.expect("get m2");
         assert_eq!(got2, p2);
 
-        // list should be sorted by agreed ascending
+        // list should be sorted by claimed ascending
         let list = repo.list_metadata(None, None).await;
         assert_eq!(list, vec![m1.clone(), m2.clone()]);
 
@@ -289,11 +289,11 @@ mod tests {
         assert_eq!(filtered, vec![m_c.clone(), m_a.clone()]);
 
         // filter by claimed < x
-        let filtered = repo.list_metadata(Some(4), None).await; // claimed < 2 => m_c(2)
+        let filtered = repo.list_metadata(Some(4), None).await; // claimed < 4 => m_b(2)
         assert_eq!(filtered, vec![m_b.clone()]);
 
         // filter by gt < claimed < lt
-        let filtered = repo.list_metadata(Some(7), Some(4)).await; // 4 < claimed < 7 => m_c(6)
+        let filtered = repo.list_metadata(Some(7), Some(4)).await; // 4 < claimed < 7 => m_a(6)
         assert_eq!(filtered, vec![m_a.clone()]);
 
         tokio::fs::remove_dir_all(dir).await.ok();

--- a/server/src/data/finalized_l1_repository.rs
+++ b/server/src/data/finalized_l1_repository.rs
@@ -9,10 +9,10 @@ use serde_json::Value;
 pub struct FinalizedL1Data {
     /// Raw JSON of the light client finality update from beacon API.
     pub raw_finality_update: Value,
-    /// Raw JSON of the light client update for the signature_slot's period.
+    /// Raw JSON of the light client update for the finalized_header.beacon.slot's period.
     /// This ensures consistency with the relayer's period calculation.
     pub raw_light_client_update: Value,
-    /// The period of the light client update (based on signature_slot).
+    /// The period of the light client update (based on finalized_header.beacon.slot).
     pub period: u64,
 }
 


### PR DESCRIPTION
## Summary

  Fix data consistency issues between preimage-maker and relayer when fetching light client data from Beacon API.

  ### Problem

  When fetching `light_client/finality_update` and `light_client/updates` at different times, the following
  inconsistencies could occur:

  1. **Period boundary mismatch**: `signature_slot` and `finalized_header.beacon.slot` can belong to different periods
  2. **Passing slot**: Finality can progress between the two API calls, causing `updates.finalized_slot >
  finality_update.finalized_slot`

  ### Solution
  - Add retry logic for the following conditions:
    - `updates.finalized_slot > finality.finalized_slot` (race condition)
    - `signature_period != finalized_period` (period boundary)