### PR TITLE
Use shared types / prepare for glamsterdam

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,10 +10,10 @@ on:
       - develop
 
 env:
-  DEVNET_REF: v1.4.0
+  DEVNET_REF: v1.4.1
   OP_TAG: op-reth/v2.3.3
   GETH_VERSION: v1.17.3
-  LODESTAR_VERSION: v1.43.0
+  LODESTAR_VERSION: v1.44.0
 
 jobs:
   lint:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,15 +155,16 @@ dependencies = [
 
 [[package]]
 name = "alloy-eip7928"
-version = "0.3.5"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec6ae911a2fc304a7cb80a79fb7bed6d1474aed4e7c203df1f8ff538f64fc78d"
+checksum = "6b827a6d7784fe3eb3489d40699407a4cdcce74271421a01bdffe60cf573bb16"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "borsh",
  "once_cell",
  "serde",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -189,7 +190,7 @@ dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
  "alloy-eip7702",
- "alloy-eip7928 0.3.5",
+ "alloy-eip7928 0.3.7",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-serde",
@@ -374,7 +375,7 @@ dependencies = [
  "rustc-hash",
  "secp256k1 0.31.1",
  "serde",
- "sha3",
+ "sha3 0.11.0",
 ]
 
 [[package]]
@@ -656,7 +657,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "sha3",
+ "sha3 0.11.0",
  "syn 2.0.117",
  "syn-solidity",
 ]
@@ -1462,6 +1463,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "blake2b_simd"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b79834656f71332577234b50bfc009996f7449e0c056884e6a02492ded0ca2f3"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "constant_time_eq",
+]
+
+[[package]]
 name = "blake3"
 version = "1.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1503,6 +1524,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "bls12_381"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3c196a77437e7cc2fb515ce413a6401291578b5afc8ecb29a3c7ab957f05941"
+dependencies = [
+ "ff 0.12.1",
+ "group 0.12.1",
+ "pairing 0.22.0",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "blst"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1540,9 +1574,9 @@ dependencies = [
 
 [[package]]
 name = "brotli-decompressor"
-version = "5.0.1"
+version = "5.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5962523e1b92ce1b5e793d9169b9943eece10d39f62550bc04bb605d75b94924"
+checksum = "3a32acac15fe1967bc3986b2a6347dffc965602354ea6f450ad07e8bfd253583"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -1880,6 +1914,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-epoch"
 version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1914,9 +1958,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
@@ -1968,9 +2012,9 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "6.2.1"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -2068,7 +2112,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
  "const-oid",
- "crypto-common 0.1.6",
+ "crypto-common 0.1.7",
  "subtle",
 ]
 
@@ -2140,9 +2184,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.16.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 dependencies = [
  "serde",
 ]
@@ -2162,9 +2206,9 @@ dependencies = [
  "base16ct",
  "crypto-bigint",
  "digest 0.10.7",
- "ff",
+ "ff 0.13.1",
  "generic-array",
- "group",
+ "group 0.13.0",
  "pkcs8",
  "rand_core 0.6.4",
  "sec1",
@@ -2233,9 +2277,9 @@ dependencies = [
 
 [[package]]
 name = "ethereum_ssz"
-version = "0.10.4"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e462875ad8693755ea8913d6e905715c76ea4836e2254e18c9cf0f7a8f8c2a13"
+checksum = "368a4a4e4273b0135111fe9464e35465067766a8f664615b5a86338b73864407"
 dependencies = [
  "alloy-primitives",
  "ethereum_serde_utils",
@@ -2248,9 +2292,9 @@ dependencies = [
 
 [[package]]
 name = "ethereum_ssz_derive"
-version = "0.10.4"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daf022360bdbe9456eda5f35718a50476d5b2a0d51a97ed4eae27420737a6fba"
+checksum = "f2cd82c68120c89361e1a457245cf212f7d9f541bffaffed530c8f2d54a160b2"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -2316,6 +2360,17 @@ dependencies = [
  "arrayvec",
  "auto_impl",
  "bytes",
+]
+
+[[package]]
+name = "ff"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
+dependencies = [
+ "bitvec",
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]
@@ -2520,9 +2575,9 @@ checksum = "1d758ba1b47b00caf47f24925c0074ecb20d6dfcffe7f6d53395c0465674841a"
 
 [[package]]
 name = "generator"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f04ae4152da20c76fe800fa48659201d5cf627c5149ca0b707b69d7eef6cf9"
+checksum = "b3b854b0e584ead1a33f18b2fcad7cf7be18b3875c78816b753639aa501513ae"
 dependencies = [
  "cc",
  "cfg-if",
@@ -2535,9 +2590,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.9"
+version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
@@ -2592,11 +2647,23 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "group"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
+dependencies = [
+ "ff 0.12.1",
+ "memuse",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
- "ff",
+ "ff 0.13.1",
  "rand_core 0.6.4",
  "subtle",
 ]
@@ -2618,6 +2685,29 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+]
+
+[[package]]
+name = "halo2"
+version = "0.1.0-beta.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a23c779b38253fe1538102da44ad5bd5378495a61d2c4ee18d64eaa61ae5995"
+dependencies = [
+ "halo2_proofs",
+]
+
+[[package]]
+name = "halo2_proofs"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e925780549adee8364c7f2b685c753f6f3df23bde520c67416e93bf615933760"
+dependencies = [
+ "blake2b_simd",
+ "ff 0.12.1",
+ "group 0.12.1",
+ "pasta_curves 0.4.1",
+ "rand_core 0.6.4",
+ "rayon",
 ]
 
 [[package]]
@@ -3189,6 +3279,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "jubjub"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a575df5f985fe1cd5b2b05664ff6accfc46559032b954529fd225a2168d27b0f"
+dependencies = [
+ "bitvec",
+ "bls12_381",
+ "ff 0.12.1",
+ "group 0.12.1",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "k256"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3200,6 +3304,15 @@ dependencies = [
  "once_cell",
  "serdect",
  "sha2 0.10.9",
+]
+
+[[package]]
+name = "keccak"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
+dependencies = [
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -3686,7 +3799,7 @@ version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee8b4f55c3dedcfaa8668de1dfc8469e7a32d441c28edf225ed1f566fb32977d"
 dependencies = [
- "ff",
+ "ff 0.13.1",
  "hex",
  "serde_arrays",
  "sha2 0.10.9",
@@ -3869,6 +3982,12 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "memuse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d97bbf43eb4f088f8ca469930cde17fa036207c9a5e02ccc5107c4e8b17c964"
 
 [[package]]
 name = "metrics"
@@ -4348,7 +4467,7 @@ dependencies = [
 [[package]]
 name = "optimism-derivation"
 version = "0.1.1"
-source = "git+https://github.com/datachainlab/optimism-elc?rev=v0.1.16#744df63e663519a95df1ac436f1f63ad1b45e4ea"
+source = "git+https://github.com/datachainlab/optimism-elc?rev=0b544acc4be483068a2f2c2be28eddd2f2816e04#0b544acc4be483068a2f2c2be28eddd2f2816e04"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4416,11 +4535,11 @@ dependencies = [
 
 [[package]]
 name = "p3-bn254-fr"
-version = "0.4.3-succinct"
+version = "0.3.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2077757c7cb514202ccb5368f521f23f5709c720599e6545c683c66e0a52d2d8"
+checksum = "577200e3fa7e49e2b21e940a6dc7399dc63acb8581da088558cdf7c455adafc0"
 dependencies = [
- "ff",
+ "ff 0.13.1",
  "num-bigint 0.4.6",
  "p3-field",
  "p3-poseidon2",
@@ -4431,9 +4550,9 @@ dependencies = [
 
 [[package]]
 name = "p3-challenger"
-version = "0.4.3-succinct"
+version = "0.3.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6a908924d43e4cfb93fb41c8346cac211b70314385a9037e9241f5b7f3eaf77"
+checksum = "75358edd6e2562752c01f5064a66d88144a3e75ace0407166dbdf8a727597f52"
 dependencies = [
  "p3-field",
  "p3-maybe-rayon",
@@ -4445,9 +4564,9 @@ dependencies = [
 
 [[package]]
 name = "p3-dft"
-version = "0.4.3-succinct"
+version = "0.3.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be6408b10a2c27eb13a7d5580c546c2179a8dc7dbc10a990657311891f9b41c0"
+checksum = "761f1e1b014f2b1b69bd0309124e233d64aa3590e6a41ee786000dd849506d51"
 dependencies = [
  "p3-field",
  "p3-matrix",
@@ -4458,9 +4577,9 @@ dependencies = [
 
 [[package]]
 name = "p3-field"
-version = "0.4.3-succinct"
+version = "0.3.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dc75969ca3ac847f43e632ab979d59ff7a68f9eac8dbf8edcbba47fc2e1d3aa"
+checksum = "2df7cebaa4079b24e0dd7e3aad59eebcbb99a67c1271f79ad884a7c032f5f183"
 dependencies = [
  "itertools 0.12.1",
  "num-bigint 0.4.6",
@@ -4472,9 +4591,9 @@ dependencies = [
 
 [[package]]
 name = "p3-koala-bear"
-version = "0.4.3-succinct"
+version = "0.3.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a9683cd0ef68100df7c62490533047bcf19c04c4a0fa1efc9d7c1e03e31f6b3"
+checksum = "6cea0ba3389b034b6088d566aea8b57aa29dd2e180966e0c8056f61331c92b4e"
 dependencies = [
  "cfg-if",
  "num-bigint 0.4.6",
@@ -4489,9 +4608,9 @@ dependencies = [
 
 [[package]]
 name = "p3-matrix"
-version = "0.4.3-succinct"
+version = "0.3.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75c3f150ceb90e09539413bf481e618d05ee19210b4e467d2902eb82d2e15281"
+checksum = "fae5cc6ce726cc265cc687c1214e3f1ac1f5c6e973442286ba00d1e75da1c3cb"
 dependencies = [
  "itertools 0.12.1",
  "p3-field",
@@ -4504,15 +4623,15 @@ dependencies = [
 
 [[package]]
 name = "p3-maybe-rayon"
-version = "0.4.3-succinct"
+version = "0.3.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0641952b42da45e1dfa2d4a2a3163e330f944ad9740942f35026c0a71a605f1"
+checksum = "55ac1d2f102cf8c71dba1b449575c99697781fcc028831e83d2245787bd7a650"
 
 [[package]]
 name = "p3-mds"
-version = "0.4.3-succinct"
+version = "0.3.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa4a5f250e174dcfca5cbeac6ad75713924e7e7320e0a335e3c50b8b1f4fe8ec"
+checksum = "5f072643e385d65fb9eb089ee6824b320417f78671a0db748566e057e28b250e"
 dependencies = [
  "itertools 0.12.1",
  "p3-dft",
@@ -4525,9 +4644,9 @@ dependencies = [
 
 [[package]]
 name = "p3-poseidon2"
-version = "0.4.3-succinct"
+version = "0.3.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "522986377b2164c5f94f2dae88e0e0a3d169cc6239202ef4aeb4322d60feffd0"
+checksum = "00cc4b6e8a439f79541b0910a016da9e6e12a05a24309bbb713e1db0db396952"
 dependencies = [
  "gcd",
  "p3-field",
@@ -4539,9 +4658,9 @@ dependencies = [
 
 [[package]]
 name = "p3-symmetric"
-version = "0.4.3-succinct"
+version = "0.3.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9047ce85c086a9b3f118e10078f10636f7bfeed5da871a04da0b61400af8793a"
+checksum = "8eebff7fea7deb08a57ccf731a0ed39df25cc66a0e0c2d92c4472c4dee02ee21"
 dependencies = [
  "itertools 0.12.1",
  "p3-field",
@@ -4550,11 +4669,20 @@ dependencies = [
 
 [[package]]
 name = "p3-util"
-version = "0.4.3-succinct"
+version = "0.3.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cff962f8eaa5f36e0447cee7c241f6b4b475fadf3ee61f154327a26bb4e009ba"
+checksum = "a8164df89bbc92e29938f916cc5f1ccbfe6a36fb5040f21ba93c1f21985b9868"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "pairing"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135590d8bdba2b31346f9cd1fb2a912329f5135e832a4f422942eb6ead8b6b3b"
+dependencies = [
+ "group 0.12.1",
 ]
 
 [[package]]
@@ -4563,7 +4691,7 @@ version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81fec4625e73cf41ef4bb6846cafa6d44736525f442ba45e407c4a000a13996f"
 dependencies = [
- "group",
+ "group 0.13.0",
 ]
 
 [[package]]
@@ -4633,6 +4761,36 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-link",
+]
+
+[[package]]
+name = "pasta_curves"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cc65faf8e7313b4b1fbaa9f7ca917a0eed499a9663be71477f87993604341d8"
+dependencies = [
+ "blake2b_simd",
+ "ff 0.12.1",
+ "group 0.12.1",
+ "lazy_static",
+ "rand 0.8.6",
+ "static_assertions",
+ "subtle",
+]
+
+[[package]]
+name = "pasta_curves"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e57598f73cc7e1b2ac63c79c517b31a0877cd7c402cdcaa311b5208de7a095"
+dependencies = [
+ "blake2b_simd",
+ "ff 0.13.1",
+ "group 0.13.0",
+ "lazy_static",
+ "rand 0.8.6",
+ "static_assertions",
+ "subtle",
 ]
 
 [[package]]
@@ -5131,6 +5289,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -6125,12 +6303,22 @@ dependencies = [
 
 [[package]]
 name = "sha3"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
+dependencies = [
+ "digest 0.10.7",
+ "keccak 0.1.6",
+]
+
+[[package]]
+name = "sha3"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1"
 dependencies = [
  "digest 0.11.3",
- "keccak",
+ "keccak 0.2.0",
 ]
 
 [[package]]
@@ -6210,9 +6398,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "slop-algebra"
-version = "6.2.4"
+version = "6.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00314224ceced0f2cbd45abd20536e9387c723985d05b8685e8785b0fe3409ce"
+checksum = "2987d60942c83511c5819afdd9ca83a9723fed072c43d5e1144393beebbce49c"
 dependencies = [
  "itertools 0.14.0",
  "p3-field",
@@ -6221,24 +6409,25 @@ dependencies = [
 
 [[package]]
 name = "slop-bn254"
-version = "6.2.4"
+version = "6.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5398ee7e1dd84faa4144b71f9dc4bacaafb13b2667bcd08b7850756e72fc7632"
+checksum = "6b3ca8edc31419a3e33a9f4b9e11f072caf5fd6e2b32f2b9fcaa5b0863f3da66"
 dependencies = [
- "ff",
+ "ff 0.13.1",
  "p3-bn254-fr",
  "serde",
  "slop-algebra",
  "slop-challenger",
  "slop-poseidon2",
  "slop-symmetric",
+ "zkhash",
 ]
 
 [[package]]
 name = "slop-challenger"
-version = "6.2.4"
+version = "6.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75cd94d7bf435f998c28bc055c4b0fa1b451e7dae4b0dbea82fb23dd4a37c6e7"
+checksum = "144e5c2ed52b6499792c98262b8bbeb435c361d005caa6f2a6c9ecb8529915b4"
 dependencies = [
  "futures",
  "p3-challenger",
@@ -6249,9 +6438,9 @@ dependencies = [
 
 [[package]]
 name = "slop-koala-bear"
-version = "6.2.4"
+version = "6.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b03d39f8c4605527970396a1a74c8e72b2adc265431fa004161aadfcfb123ff"
+checksum = "75ca44a6d3457836c6a1685dcb27b3f64c0b6f555ade06dd2a8fda5003e7594e"
 dependencies = [
  "lazy_static",
  "p3-koala-bear",
@@ -6264,27 +6453,27 @@ dependencies = [
 
 [[package]]
 name = "slop-poseidon2"
-version = "6.2.4"
+version = "6.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a17a10d1cfa6f7a18cc62d4348b0612d49eb14b7aeb289a6a14252676c04dd77"
+checksum = "3386c5935d822f8621a19f305dffdcae3d9a1956a7b657a7f8893438abf22526"
 dependencies = [
  "p3-poseidon2",
 ]
 
 [[package]]
 name = "slop-primitives"
-version = "6.2.4"
+version = "6.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62cc9b1ba7261571e853287064780a6e7f489f024d544e6344d6004f243cdf81"
+checksum = "d20475296d399080467eb486e6063967e85d3d13200301275e56541c356f96bd"
 dependencies = [
  "slop-algebra",
 ]
 
 [[package]]
 name = "slop-symmetric"
-version = "6.2.4"
+version = "6.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "362b7c414a3b5abee0d84e7418520b24d928f03bc02e0a1a05a09cf49a6a7ab8"
+checksum = "580a4f683c60b000b7ac8ca3fcd200a2a70f4caf2e43268f9089323534d15ecc"
 dependencies = [
  "p3-symmetric",
 ]
@@ -6316,9 +6505,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-lib"
-version = "6.2.4"
+version = "6.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9281c105496b6b8d20b25f0be936242e5b747cc7711a68706ffbb3719d16145d"
+checksum = "d1ce7f8d6098c930fb0c03c60f1c8b0ef61b6625811b210b2c694801ceb62f78"
 dependencies = [
  "bincode",
  "serde",
@@ -6327,9 +6516,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-primitives"
-version = "6.2.4"
+version = "6.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd38fbc3cf2e151b1d899919def510c80e7f6ca7b8fe7fdaac0e6614cd2bd286"
+checksum = "03476134330b0677d5eee5dec288cf2b0f883511c7496e55dcc9c15cf8debb47"
 dependencies = [
  "bincode",
  "blake3",
@@ -6356,9 +6545,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f23e41cd36168cc2e51e5d3e35ff0c34b204d945769a65591a76286d04b51e43"
 dependencies = [
  "cfg-if",
- "ff",
- "group",
- "pairing",
+ "ff 0.13.1",
+ "group 0.13.0",
+ "pairing 0.23.0",
  "rand_core 0.6.4",
  "sp1-lib",
  "subtle",
@@ -7988,6 +8177,33 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "zkhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4352d1081da6922701401cdd4cbf29a2723feb4cfabb5771f6fee8e9276da1c7"
+dependencies = [
+ "ark-ff 0.4.2",
+ "ark-std 0.4.0",
+ "bitvec",
+ "blake2",
+ "bls12_381",
+ "byteorder",
+ "cfg-if",
+ "group 0.12.1",
+ "group 0.13.0",
+ "halo2",
+ "hex",
+ "jubjub",
+ "lazy_static",
+ "pasta_curves 0.5.1",
+ "rand 0.8.6",
+ "serde",
+ "sha2 0.10.9",
+ "sha3 0.10.8",
+ "subtle",
 ]
 
 [[package]]

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -30,7 +30,7 @@ kona-registry = { workspace = true }
 alloy-primitives = { workspace = true, features = ["map", "serde"] }
 
 # optimism derivation
-optimism-derivation = { git = "https://github.com/datachainlab/optimism-elc", rev = "v0.1.16", default-features = false }
+optimism-derivation = { git = "https://github.com/datachainlab/optimism-elc", rev = "0b544acc4be483068a2f2c2be28eddd2f2816e04", default-features = false }
 
 [dev-dependencies]
 prost = "0.11.9"

--- a/server/src/client/beacon_client.rs
+++ b/server/src/client/beacon_client.rs
@@ -24,17 +24,35 @@ pub struct BeaconBlockHeader {
     pub slot: u64,
 }
 
-#[derive(Debug, Clone, serde::Deserialize)]
+/// LightClientHeader where `execution.block_hash` contains the block hash.
+#[derive(Debug, Clone)]
 pub struct LightClientHeader {
     pub beacon: BeaconBlockHeader,
-    pub execution: ExecutionPayloadHeader,
+    pub execution_block_hash: B256,
 }
 
-#[derive(Debug, Clone, serde::Deserialize)]
-pub struct ExecutionPayloadHeader {
-    pub block_hash: B256,
-    #[serde(deserialize_with = "deserialize_u64_from_str")]
-    pub block_number: u64,
+impl<'de> serde::Deserialize<'de> for LightClientHeader {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(serde::Deserialize)]
+        struct ExecutionPayloadHeader {
+            block_hash: B256,
+        }
+
+        #[derive(serde::Deserialize)]
+        struct RawLightClientHeader {
+            beacon: BeaconBlockHeader,
+            execution: ExecutionPayloadHeader,
+        }
+
+        let raw = RawLightClientHeader::deserialize(deserializer)?;
+        Ok(LightClientHeader {
+            beacon: raw.beacon,
+            execution_block_hash: raw.execution.block_hash,
+        })
+    }
 }
 
 #[derive(Clone, serde::Deserialize)]

--- a/server/src/client/l1_client.rs
+++ b/server/src/client/l1_client.rs
@@ -1,0 +1,97 @@
+use alloy_primitives::B256;
+use axum::async_trait;
+use serde::Deserialize;
+
+#[async_trait]
+pub trait L1Client: Send + Sync + 'static {
+    /// Returns the block number for a given block hash.
+    async fn get_block_number_by_hash(&self, hash: B256) -> anyhow::Result<u64>;
+}
+
+#[derive(Debug, Clone)]
+pub struct HttpL1Client {
+    l1_node_address: String,
+    client: reqwest::Client,
+}
+
+impl HttpL1Client {
+    pub fn new(l1_node_address: String, timeout: std::time::Duration) -> Self {
+        Self {
+            l1_node_address,
+            client: reqwest::Client::builder()
+                .timeout(timeout)
+                .build()
+                .expect("failed to build reqwest client"),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct JsonRpcResponse<T> {
+    result: Option<T>,
+    error: Option<JsonRpcError>,
+}
+
+#[derive(Debug, Deserialize)]
+struct JsonRpcError {
+    code: i64,
+    message: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct BlockResponse {
+    #[serde(deserialize_with = "deserialize_u64_from_hex")]
+    number: u64,
+}
+
+fn deserialize_u64_from_hex<'de, D>(deserializer: D) -> Result<u64, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let s: String = serde::Deserialize::deserialize(deserializer)?;
+    let s = s.strip_prefix("0x").unwrap_or(&s);
+    u64::from_str_radix(s, 16).map_err(serde::de::Error::custom)
+}
+
+#[async_trait]
+impl L1Client for HttpL1Client {
+    async fn get_block_number_by_hash(&self, hash: B256) -> anyhow::Result<u64> {
+        let request_body = serde_json::json!({
+            "jsonrpc": "2.0",
+            "method": "eth_getBlockByHash",
+            "params": [format!("{:?}", hash), false],
+            "id": 1
+        });
+
+        let response = self
+            .client
+            .post(&self.l1_node_address)
+            .json(&request_body)
+            .send()
+            .await?;
+
+        if !response.status().is_success() {
+            return Err(anyhow::anyhow!(
+                "Request failed with status: {} body={:?}",
+                response.status(),
+                response.text().await
+            ));
+        }
+
+        let json_response: JsonRpcResponse<BlockResponse> = response.json().await?;
+
+        if let Some(error) = json_response.error {
+            return Err(anyhow::anyhow!(
+                "JSON-RPC error: code={} message={}",
+                error.code,
+                error.message
+            ));
+        }
+
+        let block = json_response
+            .result
+            .ok_or_else(|| anyhow::anyhow!("Block not found for hash {:?}", hash))?;
+
+        Ok(block.number)
+    }
+}

--- a/server/src/client/mod.rs
+++ b/server/src/client/mod.rs
@@ -1,3 +1,4 @@
 pub mod beacon_client;
+pub mod l1_client;
 pub mod l2_client;
 pub mod period;

--- a/server/src/collector.rs
+++ b/server/src/collector.rs
@@ -1,4 +1,5 @@
 use crate::client::beacon_client::BeaconClient;
+use crate::client::l1_client::L1Client;
 use crate::client::l2_client::{L2Client, SyncStatus};
 use crate::client::period::compute_period_from_slot;
 use crate::data::finalized_l1_repository::{FinalizedL1Data, FinalizedL1Repository};
@@ -70,16 +71,18 @@ fn build_batch(
     batch
 }
 
-pub struct PreimageCollector<T, F, L, B, D>
+pub struct PreimageCollector<T, F, L, B, D, E>
 where
     T: PreimageRepository,
     F: FinalizedL1Repository,
     L: L2Client,
     B: BeaconClient,
     D: DerivationDriver,
+    E: L1Client,
 {
     pub client: Arc<L>,
     pub beacon_client: Arc<B>,
+    pub l1_client: Arc<E>,
     pub derivation_driver: Arc<D>,
     pub config: Arc<DerivationConfig>,
     pub preimage_repository: Arc<T>,
@@ -90,13 +93,14 @@ where
     pub interval_seconds: u64,
 }
 
-impl<T, F, L, B, D> PreimageCollector<T, F, L, B, D>
+impl<T, F, L, B, D, E> PreimageCollector<T, F, L, B, D, E>
 where
     T: PreimageRepository,
     F: FinalizedL1Repository,
     L: L2Client,
     B: BeaconClient,
     D: DerivationDriver,
+    E: L1Client,
 {
     /// Starts the asynchronous process to continually check and collect claimed metadata.
     ///
@@ -264,7 +268,24 @@ where
             }
 
             // Check block_number against sync_status
-            let block_number = finality_update.data.finalized_header.execution.block_number;
+            let execution_block_hash = finality_update.data.finalized_header.execution_block_hash;
+            let block_number = match self
+                .l1_client
+                .get_block_number_by_hash(execution_block_hash)
+                .await
+            {
+                Ok(bn) => bn,
+                Err(e) => {
+                    warn_or_error!(
+                        attempts_count,
+                        "failed to fetch block_number from L1 client: {:?}, attempts={}, retrying...",
+                        e, attempts_count
+                    );
+                    time::sleep(time::Duration::from_secs(10)).await;
+                    continue;
+                }
+            };
+
             if block_number < sync_status.finalized_l1.number {
                 warn_or_error!(
                     attempts_count,
@@ -294,14 +315,15 @@ where
             break (finalized_l1_data, finality_update);
         };
 
+        let l1_head_hash = finality_update.data.finalized_header.execution_block_hash;
+
         info!(
-            "l1_head for derivation = {:?}, finalized_slot = {}, finalized_period = {}",
-            finality_update.data.finalized_header.execution,
+            "l1_head for derivation: block_hash={:?}, finalized_slot={}, finalized_period={}",
+            l1_head_hash,
             finality_update.data.finalized_header.beacon.slot,
             finalized_l1_data.period
         );
 
-        let l1_head_hash = finality_update.data.finalized_header.execution.block_hash;
         Some((l1_head_hash, finalized_l1_data))
     }
 
@@ -422,6 +444,7 @@ mod tests {
     use crate::client::beacon_client::{
         BeaconClient, LightClientFinalityUpdateResponse, LightClientUpdateResponse,
     };
+    use crate::client::l1_client::L1Client;
     use crate::client::l2_client::{Block, L2Client, OutputRootAtBlock, SyncStatus};
     use crate::derivation::host::single::config::Config;
     use crate::derivation::host::single::handler::DerivationConfig;
@@ -487,6 +510,38 @@ mod tests {
         }
         async fn get_genesis(&self) -> anyhow::Result<crate::client::beacon_client::GenesisData> {
             Ok(crate::client::beacon_client::GenesisData { genesis_time: 0 })
+        }
+    }
+
+    struct MockL1Client {
+        block_numbers: Arc<Mutex<Vec<u64>>>,
+        call_index: Arc<Mutex<usize>>,
+    }
+
+    impl MockL1Client {
+        fn new(block_numbers: Vec<u64>) -> Self {
+            Self {
+                block_numbers: Arc::new(Mutex::new(block_numbers)),
+                call_index: Arc::new(Mutex::new(0)),
+            }
+        }
+
+        fn with_single(block_number: u64) -> Self {
+            Self::new(vec![block_number])
+        }
+    }
+
+    #[async_trait]
+    impl L1Client for MockL1Client {
+        async fn get_block_number_by_hash(&self, _hash: B256) -> anyhow::Result<u64> {
+            let mut index = self.call_index.lock().unwrap();
+            let block_numbers = self.block_numbers.lock().unwrap();
+            let block_number = block_numbers
+                .get(*index)
+                .copied()
+                .unwrap_or(*block_numbers.last().unwrap());
+            *index += 1;
+            Ok(block_number)
         }
     }
 
@@ -647,6 +702,7 @@ mod tests {
         let collector = PreimageCollector {
             client: l2_client,
             beacon_client,
+            l1_client: Arc::new(MockL1Client::with_single(95)),
             derivation_driver,
             config: derivation_config,
             preimage_repository: mock_preimage_repo.clone(),
@@ -757,6 +813,7 @@ mod tests {
         let collector = PreimageCollector {
             client: l2_client,
             beacon_client,
+            l1_client: Arc::new(MockL1Client::with_single(95)),
             derivation_driver,
             config: derivation_config,
             preimage_repository: mock_preimage_repo,
@@ -822,6 +879,7 @@ mod tests {
         let collector = PreimageCollector {
             client: l2_client,
             beacon_client,
+            l1_client: Arc::new(MockL1Client::with_single(95)),
             derivation_driver,
             config: derivation_config,
             preimage_repository: mock_preimage_repo,
@@ -917,6 +975,7 @@ mod tests {
         let collector = PreimageCollector {
             client: l2_client,
             beacon_client,
+            l1_client: Arc::new(MockL1Client::with_single(95)),
             derivation_driver,
             config: derivation_config,
             preimage_repository: mock_preimage_repo.clone(),
@@ -1041,6 +1100,7 @@ mod tests {
         let collector = PreimageCollector {
             client: l2_client,
             beacon_client,
+            l1_client: Arc::new(MockL1Client::with_single(95)),
             derivation_driver,
             config: derivation_config,
             preimage_repository: mock_preimage_repo.clone(),
@@ -1219,6 +1279,27 @@ mod tests {
         MockL2Client,
         MockBeaconClientWithRetry,
         MockDerivationDriver,
+        MockL1Client,
+    > {
+        create_collector_for_retry_test_with_block_numbers(
+            beacon_client,
+            finalized_l1_number,
+            vec![95],
+        )
+        .await
+    }
+
+    async fn create_collector_for_retry_test_with_block_numbers(
+        beacon_client: Arc<MockBeaconClientWithRetry>,
+        finalized_l1_number: u64,
+        block_numbers: Vec<u64>,
+    ) -> PreimageCollector<
+        MockPreimageRepository,
+        MockFinalizedL1Repository,
+        MockL2Client,
+        MockBeaconClientWithRetry,
+        MockDerivationDriver,
+        MockL1Client,
     > {
         let sync_status = SyncStatus {
             current_l1: dummy_l1(100),
@@ -1263,6 +1344,7 @@ mod tests {
         PreimageCollector {
             client: l2_client,
             beacon_client,
+            l1_client: Arc::new(MockL1Client::new(block_numbers)),
             derivation_driver,
             config: derivation_config,
             preimage_repository: mock_preimage_repo,
@@ -1343,14 +1425,14 @@ mod tests {
     #[tokio::test]
     async fn test_get_l1_head_retry_on_block_number_delayed() {
         // Test: block_number < sync_status.finalized_l1.number triggers retry
-        // First call: block_number=80, sync_status expects 90 -> delayed
-        // Second call: block_number=95 >= 90 -> success
+        // First call: L1 client returns block_number=80, sync_status expects 90 -> delayed
+        // Second call: L1 client returns block_number=95 >= 90 -> success
         let l1_head = B256::repeat_byte(0x11);
         let full_participation = "0x".to_string() + &"ff".repeat(4);
 
         let finality_updates = vec![
-            make_finality_update_json(l1_head, 100, 80, 105, &full_participation), // block_number=80 < 90
-            make_finality_update_json(l1_head, 100, 95, 105, &full_participation), // block_number=95 >= 90
+            make_finality_update_json(l1_head, 100, 80, 105, &full_participation),
+            make_finality_update_json(l1_head, 100, 95, 105, &full_participation),
         ];
         let light_client_updates = vec![
             make_light_client_update_json(100),
@@ -1363,7 +1445,13 @@ mod tests {
         ));
 
         // sync_status.finalized_l1.number = 90
-        let collector = create_collector_for_retry_test(beacon_client.clone(), 90).await;
+        // L1 client returns: 80 (first call, triggers retry), 95 (second call, success)
+        let collector = create_collector_for_retry_test_with_block_numbers(
+            beacon_client.clone(),
+            90,
+            vec![80, 95],
+        )
+        .await;
         let sync_status = collector.client.sync_status().await.unwrap();
 
         let result = collector.get_l1_head_and_finalized_data(&sync_status).await;

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -1,5 +1,6 @@
 #![allow(dead_code)]
 use crate::client::beacon_client::HttpBeaconClient;
+use crate::client::l1_client::HttpL1Client;
 use crate::client::l2_client::HttpL2Client;
 use crate::client::l2_client::L2Client;
 use crate::collector::{PreimageCollector, RealDerivationDriver};
@@ -53,6 +54,7 @@ async fn main() -> anyhow::Result<()> {
     );
     let beacon_client =
         HttpBeaconClient::new(config.l1_beacon_address.to_string(), http_client_timeout);
+    let l1_client = HttpL1Client::new(config.l1_node_address.to_string(), http_client_timeout);
     let chain_id = l2_client.chain_id().await?;
     let (rollup_config, l1_chain_config) = if ROLLUP_CONFIGS.get(&chain_id).is_none() {
         // devnet only
@@ -91,6 +93,7 @@ async fn main() -> anyhow::Result<()> {
     let collector = PreimageCollector {
         client: Arc::new(l2_client),
         beacon_client: Arc::new(beacon_client),
+        l1_client: Arc::new(l1_client),
         derivation_driver: Arc::new(RealDerivationDriver),
         config: Arc::new(derivation_config),
         distance: config.preimage_distance,

--- a/server/tests/e2e.rs
+++ b/server/tests/e2e.rs
@@ -123,7 +123,7 @@ pub async fn test_derivation_success() {
         let finalized_l1: LightClientFinalityUpdateResponse =
             serde_json::from_value(finalized_l1_data.raw_finality_update).unwrap();
         assert_eq!(
-            finalized_l1.data.finalized_header.execution.block_hash,
+            finalized_l1.data.finalized_header.execution_block_hash,
             metadata.l1_head
         );
 


### PR DESCRIPTION
## Changes

- Bump `optimism-derivation` (optimism-elc) to the revision that uses shared `ethereum-light-client-types`
- Stop relying on `block_number` in the light client header: only `block_hash` is
  taken from the beacon API, and the block number is fetched from the L1 execution
  node via `eth_getBlockByHash` (prepare for glamsteram)
- Bump devnet to v1.4.1, lodestar to v1.44.0